### PR TITLE
Delaying children nodes update with `_set_when_ready `function

### DIFF
--- a/TPC-demo/TestScene.tscn
+++ b/TPC-demo/TestScene.tscn
@@ -96,10 +96,11 @@ shape = SubResource("SphereShape3D_ji1ja")
 
 [node name="ThirdPersonCamera" parent="RigidBody3D" instance=ExtResource("3_ky3rl")]
 current = true
-mouse_x_sensitiveness = 0.7
+spring_arm_collision_mask = 277
 
 [node name="SpectatorCamera" type="Camera3D" parent="."]
 transform = Transform3D(-4.23762e-08, -0.245274, 0.969454, -1.07212e-08, 0.969454, 0.245274, -1, 7.01661e-14, -4.37114e-08, 47.6874, 17.5263, 0)
+current = true
 
 [node name="Map" type="Node3D" parent="."]
 

--- a/addons/third-person-camera/third_person_camera/CameraShake.gd
+++ b/addons/third-person-camera/third_person_camera/CameraShake.gd
@@ -1,3 +1,4 @@
+@tool
 extends Node3D
 class_name CameraShaker
 

--- a/addons/third-person-camera/third_person_camera/ThirdPersonCamera.tscn
+++ b/addons/third-person-camera/third_person_camera/ThirdPersonCamera.tscn
@@ -26,7 +26,7 @@ transform = Transform3D(1, 0, 0, 0, 0.939693, 0.34202, 0, -0.34202, 0.939693, 0,
 top_level = true
 
 [node name="OffsetPivot" type="Node3D" parent="RotationPivot"]
-transform = Transform3D(1, -3.9187e-07, 6.47546e-10, 3.94476e-07, 0.999999, 5.66064e-05, -2.27686e-11, -5.68202e-05, 1, 0, 0, 0)
+transform = Transform3D(1, -3.9187e-07, 6.47546e-10, 3.9448e-07, 1, 5.65946e-05, -2.27516e-11, -5.71012e-05, 1, 0, 0, 0)
 
 [node name="CameraSpringArm" type="SpringArm3D" parent="RotationPivot/OffsetPivot"]
 process_priority = 11
@@ -34,7 +34,7 @@ shape = SubResource("SeparationRayShape3D_84uqy")
 spring_length = 10.0
 
 [node name="CameraMarker" type="Marker3D" parent="RotationPivot/OffsetPivot/CameraSpringArm"]
-transform = Transform3D(1, 7.71143e-08, 3.5101e-07, 1.27095e-08, 1, -7.37009e-06, 2.14425e-07, 1.03673e-06, 1, -6.69733e-09, -0.000565967, 10)
+transform = Transform3D(1, 7.7134e-08, 3.5101e-07, 1.27097e-08, 1, -7.15256e-06, 2.14425e-07, 1.01328e-06, 1, -6.69729e-09, -0.000565767, 9.99999)
 
 [node name="PivotDebug" type="MeshInstance3D" parent="RotationPivot/OffsetPivot"]
 visible = false
@@ -45,7 +45,7 @@ script = ExtResource("2_y3uk4")
 camera = NodePath("../Camera")
 
 [node name="Camera" type="Camera3D" parent="."]
-transform = Transform3D(1, 3.21654e-15, -8.83737e-15, 0, 0.939693, 0.34202, 9.40454e-15, -0.34202, 0.939693, -8.83738e-14, 3.4202, 9.39693)
+transform = Transform3D(1, 4.65509e-15, -1.27898e-14, 0, 0.939693, 0.34202, 1.36106e-14, -0.34202, 0.939693, -1.27898e-13, 3.4202, 9.39693)
 top_level = true
 
 [node name="CameraDebug" type="MeshInstance3D" parent="Camera"]


### PR DESCRIPTION
Instead of using an array to store updates, I defined `_set_when_ready` function that check if `ThirdPersonCamera` is ready before setting the value. If it isn't, it waits for it to be ready (`await`).